### PR TITLE
deploy: bump orq-lite to v0.2.0 + self-update on start

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -26,8 +26,8 @@
 # older fork with no `flow` command) plus its version-matched default configs.
 ############################################################
 FROM debian:bookworm-slim AS orqlite
-ARG ORQ_LITE_VERSION=v0.1.26
-ARG ORQ_LITE_SHA256=d69596f1625decda3ecf747df5e5cdde881a7bd4195fa282874ff5e7dd8ea1ec
+ARG ORQ_LITE_VERSION=v0.2.0
+ARG ORQ_LITE_SHA256=7677defca9cfe2e45baae50f12374282e343f415ae9a0d0945f33a83e1e2953a
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git \
     && rm -rf /var/lib/apt/lists/*
 WORKDIR /out
@@ -39,12 +39,10 @@ RUN curl -fsSL -o orq.tgz \
     && mv "orq-lite-${ORQ_LITE_VERSION}-linux-amd64/orq-lite" /out/orq-lite \
     && chmod +x /out/orq-lite \
     && rm -rf orq.tgz "orq-lite-${ORQ_LITE_VERSION}-linux-amd64"
-# Real default configs, pinned to the same tag (the flow engine loads flows.json
-# from the working dir; the shipped flows are NOT embedded in the binary).
-RUN curl -fsSL -o /out/flows.json "https://raw.githubusercontent.com/lionelchamorro/orquesta-lite/${ORQ_LITE_VERSION}/flows.json" \
-    && curl -fsSL -o /out/team.json "https://raw.githubusercontent.com/lionelchamorro/orquesta-lite/${ORQ_LITE_VERSION}/team.json"
-# Version-matched prompts + result schemas from the binary's own scaffolder
-# (embedded); a flow's agent steps read prompts/<role>.md relative to the cwd.
+# Version-matched default configs. As of v0.2.0 the defaults are embedded in the
+# binary (no root flows.json/team.json to fetch), and `orq-lite init` scaffolds
+# flows.json (factory, factory_fast) + team.json + prompts/ + schemas/. The
+# flow engine loads flows.json + prompts/<role>.md from the run's working dir.
 RUN mkdir -p /out/scaffold && cd /out/scaffold && git init -q \
     && /out/orq-lite init >/dev/null 2>&1 || true
 
@@ -108,8 +106,11 @@ RUN npm install -g --omit=dev \
 
 # The `ubuntu` user ships at uid/gid 1000 on noble — matches the common host uid
 # so bind-mounted credential dirs stay writable (the CLIs rotate OAuth tokens in
-# place). Give it passwordless sudo for interactive convenience.
-RUN usermod -aG sudo ubuntu && passwd -d ubuntu && chsh -s /usr/bin/zsh ubuntu
+# place). Passwordless sudo (interactive convenience + the on-boot self-update,
+# which needs root to overwrite /usr/local/bin/orq-lite).
+RUN usermod -aG sudo ubuntu && passwd -d ubuntu && chsh -s /usr/bin/zsh ubuntu \
+    && printf 'ubuntu ALL=(ALL) NOPASSWD:ALL\n' > /etc/sudoers.d/90-ubuntu-nopasswd \
+    && chmod 0440 /etc/sudoers.d/90-ubuntu-nopasswd
 
 # opencode CLI + oh-my-zsh installed AS the ubuntu user (into its $HOME).
 RUN su ubuntu -c 'curl -fsSL https://opencode.ai/install | bash' \
@@ -137,11 +138,11 @@ WORKDIR /srv/api
 COPY pyproject.toml uv.lock ./
 COPY orquesta_api ./orquesta_api
 RUN uv sync --frozen --no-dev
-# Real, version-matched default configs (from the release, not this repo's old
-# fork); seeded into /data on first boot. Prompts + schemas back the flow
-# engine's agent steps.
-COPY --from=orqlite /out/team.json /srv/api/team.json
-COPY --from=orqlite /out/flows.json /srv/api/flows.json
+# Version-matched default configs scaffolded by the release binary (not this
+# repo's old fork); seeded into /data on first boot. Prompts + schemas back the
+# flow engine's agent steps.
+COPY --from=orqlite /out/scaffold/team.json /srv/api/team.json
+COPY --from=orqlite /out/scaffold/flows.json /srv/api/flows.json
 COPY --from=orqlite /out/scaffold/prompts /srv/api/orq-defaults/prompts
 COPY --from=orqlite /out/scaffold/schemas /srv/api/orq-defaults/schemas
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -137,6 +137,10 @@ COPY --from=web --chown=ubuntu:ubuntu /app /app
 WORKDIR /srv/api
 COPY pyproject.toml uv.lock ./
 COPY orquesta_api ./orquesta_api
+# Alembic config + migrations: main gates startup on the schema being at the
+# Alembic head (replaced blind create_all), so these must ship in the image.
+COPY alembic.ini ./
+COPY alembic ./alembic
 RUN uv sync --frozen --no-dev
 # Version-matched default configs scaffolded by the release binary (not this
 # repo's old fork); seeded into /data on first boot. Prompts + schemas back the

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -12,7 +12,13 @@ reverse proxy reached by IP.
 | Next.js front  | `0.0.0.0:3000`   | **yes**  | the only public port; the proxy targets it |
 | FastAPI api    | `127.0.0.1:8000` | no       | `ORQUESTA_API_URL`; spawns orq-lite per run |
 | opencode serve | `127.0.0.1:4096` | no       | `OPENCODE_SERVER_URL`; backs the global chat |
-| orq-lite       | ephemeral loopback | no     | one process **per run**, launched by the api |
+| orq-lite       | ephemeral loopback | no     | real upstream release (v0.2.0); one process **per run**, launched by the api |
+
+The container ships the real `orq-lite` release binary (github.com/lionelchamorro/
+orquesta-lite) and **self-updates on every start** via `sudo orq-lite update`
+(best-effort, time-boxed — a slow/offline start never blocks boot). Default
+flows.json / team.json / prompts are scaffolded from that binary and seeded into
+`/data` on first boot.
 
 Managed by `supervisord`; all logs go to `docker logs`.
 

--- a/deploy/orquesta-entrypoint.sh
+++ b/deploy/orquesta-entrypoint.sh
@@ -44,4 +44,15 @@ if [ -n "$GIT_TOKEN" ]; then
   echo "git: HTTPS GitHub clones authenticated via token"
 fi
 
+# --- database schema ---------------------------------------------------------
+# main gates startup on the schema being at the Alembic head (ensure_schema_current
+# raises otherwise). Upgrade an existing DB, or create a fresh one from the
+# migrations, before the API starts.
+export DATABASE_URL="${DATABASE_URL:-sqlite+aiosqlite:////data/orquesta_api.db}"
+if ( cd /srv/api && /srv/api/.venv/bin/alembic upgrade head ) 2>&1 | sed 's/^/  alembic: /'; then
+  echo "  alembic: schema at head"
+else
+  echo "  alembic: upgrade failed — the API will report schema status on start"
+fi
+
 exec supervisord -c /etc/orquesta/supervisord.conf

--- a/deploy/orquesta-entrypoint.sh
+++ b/deploy/orquesta-entrypoint.sh
@@ -12,9 +12,20 @@ if [ ! -f /data/team.json ] && [ -f /srv/api/team.json ]; then
   cp /srv/api/team.json /data/team.json
 fi
 
-# Seed default flows (real orq-lite verbs: factory / run / plan) the first time.
+# Seed the default flow-engine flows.json (factory, factory_fast) the first time.
 if [ ! -f /data/flows.json ] && [ -f /srv/api/flows.json ]; then
   cp /srv/api/flows.json /data/flows.json
+fi
+
+# --- keep orq-lite current ---------------------------------------------------
+# Self-update to the latest release on every start. Best-effort and time-boxed
+# so an offline start or a slow download can't block boot; needs root (sudo) to
+# overwrite /usr/local/bin/orq-lite.
+echo "orq-lite: $(orq-lite version 2>/dev/null) — checking for updates…"
+if timeout 90 sudo -n orq-lite update 2>&1 | sed 's/^/  orq-lite update: /'; then
+  echo "orq-lite: now $(orq-lite version 2>/dev/null)"
+else
+  echo "  orq-lite update: skipped (offline, already latest, or timed out)"
 fi
 
 # --- git auth for cloning private repos --------------------------------------


### PR DESCRIPTION
## What

Bump the bundled `orq-lite` to the **v0.2.0** release and make the container
**self-update on every start**.

- `deploy/Dockerfile`: pin `orq-lite v0.2.0` (sha-verified). v0.2.0 embeds its
  default configs, so scaffold `flows.json` (factory, factory_fast) + `team.json`
  + `prompts/` + `schemas/` via `orq-lite init` instead of fetching root config
  files that no longer exist upstream at that tag.
- `deploy/orquesta-entrypoint.sh`: run `sudo -n orq-lite update` on every boot
  (best-effort, time-boxed 90s so an offline/slow start can't block startup);
  passwordless sudo for `ubuntu` lets it overwrite `/usr/local/bin/orq-lite`.
- `deploy/README.md`: document the above.

## Verified

Built and ran the container: reports `v0.2.0`, the on-boot update check runs
(`current: v0.2.0 / latest: v0.2.0 / already up to date`), and the real
flows/team are seeded into `/data`.

## Heads-up (not in this PR)

`main` now uses **Alembic** for the schema (the app lifespan no longer does
`create_all`), but `deploy/` has **no migration step** — the container would
start the API with no tables. A follow-up should run `alembic upgrade head` in
the entrypoint (or api start) before/at boot. Flagging so this isn't a surprise
when the deploy is next run against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
