### PR TITLE
fix: dashboard live data, project-detail null-guard, dead settings link

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react"
 import { ConsoleSidebar } from "@/components/console/console-sidebar"
 import { getProjects } from "@/lib/orq-lite"
 
+// The dashboard reads live control-plane state (projects, flows, teams). Without
+// this the pages get statically prerendered at build time — when the API isn't
+// running — and serve a permanently-empty registry. Render on demand instead.
+export const dynamic = "force-dynamic"
+
 export default async function DashboardLayout({ children }: { children: ReactNode }) {
   const projects = await getProjects()
 

--- a/components/console/console-sidebar.tsx
+++ b/components/console/console-sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { LayoutDashboard, Boxes, MessagesSquare, Users, Settings, Workflow, Gamepad2, LogOut } from "lucide-react"
+import { LayoutDashboard, Boxes, MessagesSquare, Users, Workflow, Gamepad2, LogOut } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { BrandWordmark } from "@/components/brand-mark"
 import type { Project } from "@/lib/types"
@@ -89,13 +89,6 @@ export function ConsoleSidebar({ projects }: { projects: Project[] }) {
         </div>
       </div>
       <div className="mt-auto border-t border-border p-3">
-        <Link
-          href="/dashboard/settings"
-          className="flex items-center gap-3 rounded-lg px-3 py-2 font-mono text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent/50 hover:text-foreground"
-        >
-          <Settings className="h-4 w-4" />
-          Settings
-        </Link>
         <form action={logout}>
           <button
             type="submit"

--- a/orquesta_api/services/aggregator.py
+++ b/orquesta_api/services/aggregator.py
@@ -63,9 +63,13 @@ class Aggregator:
         base_url = f"http://127.0.0.1:{port}"
         logger.info("Fetching snapshot => project_id=%s base_url=%s", project_id, base_url)
 
-        tasks_resp = await self._client.get_tasks(base_url)
-        factory_resp = await self._client.get_factory(base_url)
-        cost_resp = await self._client.get_cost(base_url)
+        # orq-lite serves these files verbatim and returns JSON `null` when a
+        # file is absent (e.g. factory.json for a project that hasn't run a
+        # factory yet — i.e. every freshly-registered project), so coalesce to
+        # an empty dict before reading keys.
+        tasks_resp = await self._client.get_tasks(base_url) or {}
+        factory_resp = await self._client.get_factory(base_url) or {}
+        cost_resp = await self._client.get_cost(base_url) or {}
 
         return Snapshot(
             tasks=[Task(**t) for t in tasks_resp.get("tasks", [])],


### PR DESCRIPTION
Three runtime bugs surfaced while deploying `main` in the all-in-one container
(each reproduces with a fresh registry — no prior state needed):

## 1. Dashboard served stale/empty data
`/dashboard/projects|flows|team` are server components that read live
control-plane state, but they had no dynamic marker, so `next build`
**statically prerendered** them (with the API down → empty). A newly registered
project never appeared until a rebuild. Fix: `export const dynamic = "force-dynamic"`
on the dashboard layout (route table now shows these as `ƒ`, not `○`).

## 2. Project detail 500 for any fresh project
`orq-lite serve` returns JSON **`null`** for `/api/factory` (and tasks/cost) when
the file is absent — which is the case for every project that hasn't run a
factory yet. `Aggregator.snapshot()` did `factory_resp.get("features", [])` on
that `None` → `AttributeError` → 500, which the front rendered as a 404 when you
click a project. Fix: coalesce the client responses to `{}`.

## 3. Dead "Settings" sidebar link
`href="/dashboard/settings"` points to a page that doesn't exist → 404 on click
(and an RSC prefetch 404 in the console). Removed the link + its unused import.

All three verified live in the container (project detail returns 200, registry
lists newly-added projects, no settings 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
