### PR TITLE
fix(watcher): install gh in image and honour per-project watch flags

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -101,6 +101,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && locale-gen \
     && rm -rf /var/lib/apt/lists/*
 
+# GitHub CLI (gh) from GitHub's official apt repo. Required by orq-lite's issue/PR
+# watcher (`gh issue list` / `gh pr ...`); without it every watch tick fails and
+# the project flips to needs_human. Not in the ubuntu default repos, so add the
+# signed source. Auth is provided at runtime (mounted ~/.config/gh or GH_TOKEN).
+RUN mkdir -p -m 755 /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends gh \
+    && rm -rf /var/lib/apt/lists/*
+
 # Node.js 22 system-wide (NodeSource) — reliable for supervised services and the
 # npm-installed agent CLIs (chosen over nvm so non-login shells resolve node).
 RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/orquesta_api/executors/local.py
+++ b/orquesta_api/executors/local.py
@@ -14,6 +14,23 @@ from orquesta_api.meta.models import Container, RunHandle, RunKind, RunSpec, Run
 logger = get_logger(__name__)
 
 
+def _watch_argv(bin_path: str, spec: RunSpec) -> list[str]:
+    """Build the `watch` invocation, honouring the project's watch targets.
+
+    Passes --prs/--issues only for the enabled targets rather than watching both
+    unconditionally. A watch with no targets is a no-op that would exit and (per
+    the run supervisor) flip the project to needs_human, so reject it up front.
+    """
+    if not (spec.watch_prs or spec.watch_issues):
+        raise ValueError("watch runs require at least one of watch_prs / watch_issues")
+    argv = [bin_path, "watch"]
+    if spec.watch_prs:
+        argv.append("--prs")
+    if spec.watch_issues:
+        argv.append("--issues")
+    return argv
+
+
 def build_argv(bin_path: str, spec: RunSpec) -> list[str]:
     """Map a RunSpec to the exact orq-lite CLI invocation (subcommand first).
 
@@ -38,7 +55,7 @@ def build_argv(bin_path: str, spec: RunSpec) -> list[str]:
             argv = [bin_path, "flow", "run", spec.flow]
             argv.extend(f"{k}={v}" for k, v in spec.inputs.items())
         case RunKind.watch:
-            argv = [bin_path, "watch", "--prs", "--issues"]
+            argv = _watch_argv(bin_path, spec)
     return [*argv, *spec.args]
 
 

--- a/orquesta_api/meta/models.py
+++ b/orquesta_api/meta/models.py
@@ -227,6 +227,11 @@ class RunSpec(BaseModel):
     flow: str | None = None
     inputs: dict[str, str] = Field(default_factory=dict)
     args: list[str] = Field(default_factory=list)
+    # Watch targets, mirrored from the project's watch settings. Only consulted
+    # for RunKind.watch; other kinds ignore them. Default True preserves the
+    # historical "watch everything" behaviour when a caller omits them.
+    watch_prs: bool = True
+    watch_issues: bool = True
 
 
 class RunHandle(BaseModel):

--- a/orquesta_api/services/examples_overlay.py
+++ b/orquesta_api/services/examples_overlay.py
@@ -22,7 +22,9 @@ logger = get_logger(__name__)
 _EXAMPLES_DIR = os.environ.get("ORQ_EXAMPLES_DIR", "/srv/api/orq-examples")
 
 
-def _load(path: Path) -> dict[str, Any]:
+def _load(path: Path) -> dict[str, Any]:  # ast-grep-ignore: no-dict-return-annotation
+    # JSON-deserialization boundary: flows.json / team.json are open-ended docs
+    # merged key-by-key (dynamic role/agent names), so a dict is the correct type.
     return json.loads(path.read_text()) if path.exists() else {}
 
 

--- a/orquesta_api/services/runs.py
+++ b/orquesta_api/services/runs.py
@@ -164,6 +164,14 @@ class RunSupervisor:
         if project is None:
             raise ValueError(f"Project '{project_id}' not found")
 
+        # A watch run with neither target enabled would watch nothing, exit, and
+        # get the project flipped to needs_human. Reject before creating a row.
+        if kind is RunKind.watch and not (project.watch_prs or project.watch_issues):
+            raise ValueError(
+                f"Project '{project_id}' has no watch targets enabled "
+                "(set watch.prs and/or watch.issues)"
+            )
+
         # Reject concurrent launches for the same project.
         existing = await self._session.execute(
             select(RunRow).where(
@@ -198,6 +206,8 @@ class RunSupervisor:
             flow=flow,
             inputs=inputs or {},
             args=args or [],
+            watch_prs=project.watch_prs,
+            watch_issues=project.watch_issues,
         )
 
         handle: RunHandle = await self._executor.start(spec, run_id=run_id)

--- a/test/test_argv.py
+++ b/test/test_argv.py
@@ -29,6 +29,19 @@ def spec(**kw) -> RunSpec:
             ),
             ["orq-lite", "flow", "run", "pr_review", "pr_number=42", "publish=true"],
         ),
+        # Watch honours the per-project targets rather than hardcoding both.
+        (
+            spec(kind=RunKind.watch),
+            ["orq-lite", "watch", "--prs", "--issues"],
+        ),
+        (
+            spec(kind=RunKind.watch, watch_prs=True, watch_issues=False),
+            ["orq-lite", "watch", "--prs"],
+        ),
+        (
+            spec(kind=RunKind.watch, watch_prs=False, watch_issues=True),
+            ["orq-lite", "watch", "--issues"],
+        ),
     ],
 )
 def test_build_argv(s: RunSpec, expected: list[str]) -> None:
@@ -43,3 +56,11 @@ def test_flow_requires_name() -> None:
 def test_plan_requires_path() -> None:
     with pytest.raises(ValueError, match="plan_path"):
         build_argv("orq-lite", spec(kind=RunKind.plan))
+
+
+def test_watch_requires_a_target() -> None:
+    with pytest.raises(ValueError, match="watch_prs / watch_issues"):
+        build_argv(
+            "orq-lite",
+            spec(kind=RunKind.watch, watch_prs=False, watch_issues=False),
+        )


### PR DESCRIPTION
## Why

`prm` was stuck in `needs_human`. Two root causes, both fixed here.

### 1. `gh` was missing from the deploy image
The issue/PR watcher shells out to `gh` (`gh issue list`, `gh pr ...`), but `deploy/Dockerfile` never installed it. Every watch tick failed with `exec: "gh": executable file not found in $PATH`; after 10 consecutive failures the watch aborted with exit 1, and the run supervisor flips a non-zero-exit project to `needs_human`. `gh` had only ever been dropped into the running container by hand, so it would not survive a clean rebuild.

**Fix:** install `gh` from GitHub's official signed apt repo. Validated end-to-end in a throwaway `ubuntu:24.04` container (installs `gh 2.96.0`).

### 2. The watcher ignored per-project watch settings
`build_argv` hardcoded `watch --prs --issues`, so a project with `watch.prs: false` (like `prm`) still got all its PRs auto-reviewed — and orq-lite then persisted `prs: true` into the workspace `watch.json`.

**Fix:** thread the project's `watch_prs` / `watch_issues` through `RunSpec` and emit only the enabled `--prs` / `--issues` flags. A watch run with no targets enabled would be a no-op that exits and re-triggers `needs_human`, so it's rejected up front — in `launch()` (HTTP 400) and defensively in `build_argv`.

## Changes
- `deploy/Dockerfile` — install `gh` from the official apt repo
- `orquesta_api/meta/models.py` — `RunSpec` carries `watch_prs` / `watch_issues`
- `orquesta_api/services/runs.py` — mirror project watch flags into the spec; reject a target-less watch
- `orquesta_api/executors/local.py` — `build_argv` honours the flags (extracted `_watch_argv`)
- `test/test_argv.py` — cover the watch case (previously untested)

## Verification
- `156 passed`, ruff clean
- `gh` apt stanza proven in a real `ubuntu:24.04` container

## Follow-ups (not in this PR)
- The image must be rebuilt for these to take effect (cap the Next build's memory).
- `prm`'s workspace `watch.json` on the `/data` volume still has `prs: true` persisted from earlier runs; orq-lite owns that file, so it needs a separate reset if `prm` should stop watching PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)