### PR TITLE
fix(runs): flip project.state to running on launch so live events connect

### DIFF
--- a/components/console/live-events.tsx
+++ b/components/console/live-events.tsx
@@ -98,21 +98,19 @@ const connectionDot: Record<ConnectionState, string> = {
 export function LiveEvents({
   projectId,
   initial,
-  live,
 }: {
   projectId: string
   initial: RunEvent[]
-  live: boolean
 }) {
   const [events, setEvents] = useState<RunEvent[]>(initial)
-  // Only EventSource callbacks (async) write this; the displayed state is
-  // derived below with the `live` gate, so the effect never sets state
-  // synchronously (react-hooks set-state-in-effect).
+  // Only EventSource callbacks (async) write this (react-hooks set-state-in-effect).
+  // The SSE stays open regardless of project.state — events flow whenever a run
+  // (factory OR the background watch daemon) is active, so the panel must not be
+  // gated on the project being "running".
   const [esState, setEsState] = useState<Exclude<ConnectionState, "idle">>("connecting")
   const listRef = useRef<HTMLUListElement>(null)
 
   useEffect(() => {
-    if (!live) return
     const es = new EventSource(`/api/control-plane/projects/${projectId}/events`)
     es.onopen = () => setEsState("streaming")
     es.onmessage = (message) => {
@@ -125,9 +123,9 @@ export function LiveEvents({
       setEsState("error")
     }
     return () => es.close()
-  }, [live, projectId])
+  }, [projectId])
 
-  const connection: ConnectionState = live ? esState : "idle"
+  const connection: ConnectionState = esState
 
   useEffect(() => {
     const el = listRef.current

--- a/components/console/project-view.tsx
+++ b/components/console/project-view.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react"
 import Link from "next/link"
-import { useRouter } from "next/navigation"
 import { GitBranch, Folder, GitPullRequest, CircleDot, Gamepad2, Radar } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -20,7 +19,6 @@ type Tab = (typeof tabs)[number]
 
 export function ProjectView({ project }: { project: Project }) {
   const [tab, setTab] = useState<Tab>("Factory")
-  const live = project.state === "running"
 
   return (
     <div className="grid flex-1 xl:grid-cols-[minmax(0,1fr)_420px]">
@@ -89,7 +87,7 @@ export function ProjectView({ project }: { project: Project }) {
       {/* right rail: live events */}
       <div className="hidden border-l border-border xl:block">
         <div className="sticky top-16 h-[calc(100dvh-4rem)]">
-          <LiveEvents projectId={project.id} initial={project.events} live={live} />
+          <LiveEvents projectId={project.id} initial={project.events} />
         </div>
       </div>
     </div>
@@ -97,7 +95,6 @@ export function ProjectView({ project }: { project: Project }) {
 }
 
 export function ProjectActions({ project }: { project: Project }) {
-  const router = useRouter()
   const [launchingWatch, setLaunchingWatch] = useState(false)
   const [watchMessage, setWatchMessage] = useState("")
 
@@ -123,9 +120,6 @@ export function ProjectActions({ project }: { project: Project }) {
         return
       }
       setWatchMessage("watch daemon started")
-      // Re-fetch the server component so project.state (now "running") flows
-      // back down and LiveEvents opens the SSE connection.
-      router.refresh()
     } catch (err) {
       setWatchMessage(`launch failed: ${err instanceof Error ? err.message : String(err)}`)
     } finally {

--- a/components/console/project-view.tsx
+++ b/components/console/project-view.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
 import { GitBranch, Folder, GitPullRequest, CircleDot, Gamepad2, Radar } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
@@ -96,6 +97,7 @@ export function ProjectView({ project }: { project: Project }) {
 }
 
 export function ProjectActions({ project }: { project: Project }) {
+  const router = useRouter()
   const [launchingWatch, setLaunchingWatch] = useState(false)
   const [watchMessage, setWatchMessage] = useState("")
 
@@ -121,6 +123,9 @@ export function ProjectActions({ project }: { project: Project }) {
         return
       }
       setWatchMessage("watch daemon started")
+      // Re-fetch the server component so project.state (now "running") flows
+      // back down and LiveEvents opens the SSE connection.
+      router.refresh()
     } catch (err) {
       setWatchMessage(`launch failed: ${err instanceof Error ? err.message : String(err)}`)
     } finally {

--- a/orquesta_api/services/runs.py
+++ b/orquesta_api/services/runs.py
@@ -217,10 +217,12 @@ class RunSupervisor:
         row.container_id = handle.container_id
         row.started_at = datetime.now(tz=UTC)
         row.state = RunState.running.value
-        # Flip the project to running so the frontend opens the live-events
-        # EventSource (gated on project.state === "running"). _supervise resets
-        # it to idle/needs_human when the run finishes.
-        project.state = "running"
+        # A foreground run marks the project running so the UI disables the flow
+        # launcher while it executes. A watch daemon is a long-lived background
+        # supervisor — it must NOT, or the launcher would stay disabled for its
+        # whole life. stop()/_supervise reset the project when the run ends.
+        if kind is not RunKind.watch:
+            project.state = "running"
 
         await self._session.commit()
 
@@ -248,8 +250,13 @@ class RunSupervisor:
                 logger.warning("_supervise: RunRow %s not found; skipping", run_id)
                 return
 
-            # Don't clobber a state already written by stop() or a prior call.
-            if RunState(row.state) not in _ACTIVE_RUN_STATES:
+            # stop() marks the row stopping (then cancelled) before killing the
+            # process, so a SIGTERM exit is a user cancellation, not a failure.
+            stopped = RunState(row.state) in (RunState.stopping, RunState.cancelled)
+
+            # A natural terminal state (succeeded/failed) was already written by a
+            # prior call — respect it. A stop-in-progress still needs finalizing.
+            if RunState(row.state) not in _ACTIVE_RUN_STATES and not stopped:
                 logger.info(
                     "_supervise: run %s already terminal (state=%s); skipping",
                     run_id,
@@ -260,16 +267,21 @@ class RunSupervisor:
             now = datetime.now(tz=UTC)
             row.exit_code = exit_code
             row.finished_at = now
-            row.state = RunState.succeeded.value if exit_code == 0 else RunState.failed.value
+            if stopped:
+                row.state = RunState.cancelled.value
+                project_state = "idle"
+            else:
+                row.state = RunState.succeeded.value if exit_code == 0 else RunState.failed.value
+                project_state = "idle" if exit_code == 0 else "needs_human"
+            final_state = row.state
 
             project = await session.get(ProjectRow, row.project_id)
             if project is not None:
                 project.last_run = now
-                project.state = "idle" if exit_code == 0 else "needs_human"
+                project.state = project_state
 
             await session.commit()
 
-        final_state = RunState.succeeded.value if exit_code == 0 else RunState.failed.value
         await self._emit_lifecycle(row, EventKind.run_finished, status=final_state)
         logger.info("_supervise: run %s finished => exit_code=%s", run_id, exit_code)
 
@@ -298,7 +310,10 @@ class RunSupervisor:
         was_running = live_state_before not in (RunState.succeeded, RunState.failed)
 
         row.state = RunState.stopping.value
-        await self._session.flush()
+        # Commit (not just flush) so _supervise's separate session observes the
+        # stopping marker and treats the resulting SIGTERM exit as a user
+        # cancellation (→ project idle) rather than a failure (→ needs_human).
+        await self._session.commit()
 
         await self._executor.stop(handle)
 

--- a/orquesta_api/services/runs.py
+++ b/orquesta_api/services/runs.py
@@ -217,6 +217,10 @@ class RunSupervisor:
         row.container_id = handle.container_id
         row.started_at = datetime.now(tz=UTC)
         row.state = RunState.running.value
+        # Flip the project to running so the frontend opens the live-events
+        # EventSource (gated on project.state === "running"). _supervise resets
+        # it to idle/needs_human when the run finishes.
+        project.state = "running"
 
         await self._session.commit()
 

--- a/test/test_run_lifecycle.py
+++ b/test/test_run_lifecycle.py
@@ -115,17 +115,26 @@ async def test_happy_path_succeeds(db, project: str, fake_bin: str, tmp_path: Pa
 
 
 # ---------------------------------------------------------------------------
-# Step 1b: Launch flips project.state to running (gates the live-events SSE)
+# Step 1b: project.state reflects an active *foreground* run (the "busy" gate
+# that disables the flow launcher). A watch daemon is a background supervisor
+# and must NOT flip it, or the launcher stays disabled for the daemon's life.
 # ---------------------------------------------------------------------------
+
+
+async def _enable_watch(db, project_id: str) -> None:
+    async with db() as session:
+        row = await session.get(ProjectRow, project_id)
+        row.watch_issues = True
+        await session.commit()
 
 
 async def test_launch_marks_project_running(
     monkeypatch, db, project: str, fake_bin: str, tmp_path: Path
 ) -> None:
-    """While a run is active, the project reports running.
+    """A foreground run (factory/flow/run) flips the project to running.
 
-    The frontend opens the live-events EventSource only when
-    ``project.state === "running"``; without this the SSE never connects.
+    The frontend disables the flow launcher while ``project.state === "running"``
+    so a second run can't be launched over an active one.
     """
     # Keep the process alive so the supervisor cannot finalize mid-assertion.
     monkeypatch.setenv("FAKE_SLEEP_S", "10")
@@ -149,6 +158,65 @@ async def test_launch_marks_project_running(
         svc = RunSupervisor(session, executor=executor, session_maker=db)
         await svc.stop(run.id)
     await _wait_for_supervisor_tasks()
+
+
+async def test_watch_launch_does_not_mark_project_running(
+    monkeypatch, db, project: str, fake_bin: str, tmp_path: Path
+) -> None:
+    """A watch daemon is a background supervisor — it must NOT flip the project
+    to running, otherwise the flow launcher stays disabled for its whole life."""
+    monkeypatch.setenv("FAKE_SLEEP_S", "10")
+    await _enable_watch(db, project)
+
+    log_dir = tmp_path / "run-logs"
+    executor = LocalExecutor(bin_path=fake_bin, log_dir=log_dir)
+
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        run = await svc.launch(project, kind=RunKind.watch)
+
+    assert run.state == RunState.running  # the RUN is running…
+
+    async with db() as session:
+        proj = await session.get(ProjectRow, project)
+        assert proj is not None
+        # …but the PROJECT stays idle so the launcher remains usable.
+        assert proj.state == "idle", f"expected idle, got {proj.state}"
+
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        await svc.stop(run.id)
+    await _wait_for_supervisor_tasks()
+
+
+async def test_stop_resets_project_state(
+    monkeypatch, db, project: str, fake_bin: str, tmp_path: Path
+) -> None:
+    """Stopping a run resets project.state — otherwise a stopped foreground run
+    leaves the project stuck 'running' and the launcher disabled forever."""
+    monkeypatch.setenv("FAKE_SLEEP_S", "30")
+
+    log_dir = tmp_path / "run-logs"
+    executor = LocalExecutor(bin_path=fake_bin, log_dir=log_dir)
+
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        run = await svc.launch(project, kind=RunKind.run)
+
+    # Precondition: launch set it running.
+    async with db() as session:
+        proj = await session.get(ProjectRow, project)
+        assert proj.state == "running"
+
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        await svc.stop(run.id)
+    await _wait_for_supervisor_tasks()
+
+    async with db() as session:
+        proj = await session.get(ProjectRow, project)
+        assert proj is not None
+        assert proj.state == "idle", f"expected idle after stop, got {proj.state}"
 
 
 # ---------------------------------------------------------------------------

--- a/test/test_run_lifecycle.py
+++ b/test/test_run_lifecycle.py
@@ -115,6 +115,43 @@ async def test_happy_path_succeeds(db, project: str, fake_bin: str, tmp_path: Pa
 
 
 # ---------------------------------------------------------------------------
+# Step 1b: Launch flips project.state to running (gates the live-events SSE)
+# ---------------------------------------------------------------------------
+
+
+async def test_launch_marks_project_running(
+    monkeypatch, db, project: str, fake_bin: str, tmp_path: Path
+) -> None:
+    """While a run is active, the project reports running.
+
+    The frontend opens the live-events EventSource only when
+    ``project.state === "running"``; without this the SSE never connects.
+    """
+    # Keep the process alive so the supervisor cannot finalize mid-assertion.
+    monkeypatch.setenv("FAKE_SLEEP_S", "10")
+
+    log_dir = tmp_path / "run-logs"
+    executor = LocalExecutor(bin_path=fake_bin, log_dir=log_dir)
+
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        run = await svc.launch(project, kind=RunKind.run)
+
+    assert run.state == RunState.running
+
+    async with db() as session:
+        proj = await session.get(ProjectRow, project)
+        assert proj is not None
+        assert proj.state == "running", f"expected running, got {proj.state}"
+
+    # Cleanup: stop the long-lived run so the supervisor task settles quickly.
+    async with db() as session:
+        svc = RunSupervisor(session, executor=executor, session_maker=db)
+        await svc.stop(run.id)
+    await _wait_for_supervisor_tasks()
+
+
+# ---------------------------------------------------------------------------
 # Step 2: Failure path — exit 3 → failed, project.state = needs_human
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

Launching a run (especially **"Start watch daemon"**) showed no live events in the UI — the "Live events" panel stayed on `idle` / "No events yet".

## Root cause

The panel opened its SSE `EventSource` only when `project.state === "running"` (`live-events.tsx`), but `RunSupervisor.launch` set only the **run** row to `running`, never the **project** — so `project.state` stayed `idle` and the EventSource never opened. The serve→bus→SSE pipeline itself was healthy (verified end-to-end).

## Fix (two commits)

**1. `c9a7b73` — mark the project running on launch + refresh the UI.**

**2. `6226617` — decouple the watch daemon from the running-state.** The first commit regressed the flow launcher: a long-lived watch daemon held `project.state="running"` forever, disabling the flow `<select>` + Run button (`flow-launcher.tsx` gates on `project.state === "running"`). `stop()` also left the project stuck because it never reset `project.state`.

- **`runs.py` `launch()`**: only *foreground* runs (factory/flow/run/plan) mark the project running. A watch daemon is a background supervisor and must not.
- **`runs.py` `stop()`/`_supervise()`**: `stop()` commits the `stopping` marker so `_supervise`'s separate session sees it and finalizes the SIGTERM exit as a **cancellation → project idle** (not a failure → needs_human); `_supervise` resets `project.state` even when `stop()` finalized the run first.
- **`live-events.tsx`**: open the SSE unconditionally (no longer gated on `project.state`) so events flow for the watch daemon too — without coupling to the launcher's busy-state.
- **`project-view.tsx`**: drop the now-unused `live` prop / `router.refresh()`.

## Verification

- Backend suite: **143 passed** (incl. `test_launch_marks_project_running`, `test_watch_launch_does_not_mark_project_running`, `test_stop_resets_project_state`).
- **Live deploy** (rebuilt image, recreated container):
  - Watch daemon active → `project.state` is **not** `running` → flow launcher stays enabled. ✓
  - Stopping a run → `project.state` resets to `idle` (not stuck / not needs_human). ✓
  - Watcher detects a new issue and runs intake end-to-end; events stream over `/projects/{id}/events`. ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
