### PR TITLE
fix(chat): crypto.randomUUID crashes over insecure (HTTP) origins

### DIFF
--- a/components/console/global-chat.tsx
+++ b/components/console/global-chat.tsx
@@ -3,7 +3,7 @@
 import { useState, useRef, useEffect } from "react"
 import { createOpencodeClient, type OpencodeClient } from "@opencode-ai/sdk/client"
 import { Send, Sparkles, Loader2, CornerDownLeft, Wrench } from "lucide-react"
-import { cn } from "@/lib/utils"
+import { cn, uid } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import type { ChatMessage } from "@/lib/types"
 
@@ -60,7 +60,7 @@ export function GlobalChat({ compact = false }: { compact?: boolean }) {
   async function send(text: string) {
     const content = text.trim()
     if (!content || loading) return
-    setMessages((prev) => [...prev, { id: crypto.randomUUID(), role: "user", content }])
+    setMessages((prev) => [...prev, { id: uid(), role: "user", content }])
     setInput("")
     setLoading(true)
     setToolCalls([])
@@ -76,13 +76,13 @@ export function GlobalChat({ compact = false }: { compact?: boolean }) {
       if (tools.length) setToolCalls(tools)
       setMessages((prev) => [
         ...prev,
-        { id: crypto.randomUUID(), role: "assistant", content: reply || "(the agent returned no text)" },
+        { id: uid(), role: "assistant", content: reply || "(the agent returned no text)" },
       ])
     } catch (err) {
       setMessages((prev) => [
         ...prev,
         {
-          id: crypto.randomUUID(),
+          id: uid(),
           role: "assistant",
           content: `Could not reach the agent: ${err instanceof Error ? err.message : String(err)}`,
         },

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,21 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+// A random id for client-side keys/local records. `crypto.randomUUID` only
+// exists in secure contexts (HTTPS or localhost), so it throws when the app is
+// reached over plain HTTP by IP/domain — which crashed the chat. Fall back to
+// `crypto.getRandomValues` (available in insecure contexts) and finally to a
+// non-crypto id. These ids are not security-sensitive.
+export function uid(): string {
+  const c: Crypto | undefined = typeof crypto !== 'undefined' ? crypto : undefined
+  if (c?.randomUUID) return c.randomUUID()
+  if (c?.getRandomValues) {
+    const b = c.getRandomValues(new Uint8Array(16))
+    b[6] = (b[6] & 0x0f) | 0x40
+    b[8] = (b[8] & 0x3f) | 0x80
+    const h = Array.from(b, (x) => x.toString(16).padStart(2, '0'))
+    return `${h[0]}${h[1]}${h[2]}${h[3]}-${h[4]}${h[5]}-${h[6]}${h[7]}-${h[8]}${h[9]}-${h[10]}${h[11]}${h[12]}${h[13]}${h[14]}${h[15]}`
+  }
+  return `id-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}


### PR DESCRIPTION
## Problem

Over the deploy accessed by IP/domain, the chat (and the whole project page) failed with:

> Could not load this project. **crypto.randomUUID is not a function**

## Root cause

`crypto.randomUUID()` only exists in a **secure context** (HTTPS or `localhost`). Reached over plain HTTP by IP/domain, `crypto.randomUUID` is `undefined`. `global-chat.tsx` called it at the top of `send()` — **outside** the `try/catch` — so the throw bubbled up to the project error boundary (`app/projects/[id]/error.tsx`), which renders `"Could not load this project."` + the error message.

## Fix

Add a `uid()` helper (`lib/utils.ts`) that:
1. prefers `crypto.randomUUID()` (secure contexts),
2. falls back to `crypto.getRandomValues()` — **available in insecure contexts** — to build an RFC-4122 v4 id,
3. finally falls back to a non-crypto id.

These ids are local React keys / message ids, not security-sensitive. The three `crypto.randomUUID()` calls in the chat now use `uid()`.

## Verification

- `pnpm typecheck` clean for the changed files.
- Verified the fallback path (with `randomUUID` unavailable) produces unique, valid v4 uuids and never throws.

Note: the real fix for production is either serving the app over HTTPS or this change; this makes the app work in both contexts.
